### PR TITLE
Auto-next on pass

### DIFF
--- a/dmriqcpy/template/libs/js/scripts.js
+++ b/dmriqcpy/template/libs/js/scripts.js
@@ -388,6 +388,7 @@ $(document).ready(function () {
             var subj_id = tab.getElementsByClassName("tab")[dict_metrics[currentMetric]].id;
             update_status(document.getElementById(subj_id + "_pass"));
             qc_saved = false;
+            nextPrev(1);
         }
         else if (e.key == "2") {
             var tab = document.getElementById(currentMetric);


### PR DESCRIPTION
Automatically move to the next item when selecting the "Pass" status (pressing the "1" button).

I think it would make QC faster, especially when most items are OK. 
Maybe this should be an optional trigger instead of always automatically moving to the next report item, what do you think?